### PR TITLE
Refactor request handling

### DIFF
--- a/cloud_builder/cb_prepare.py
+++ b/cloud_builder/cb_prepare.py
@@ -27,7 +27,8 @@ options:
         Path to the package
 
     --profile=<dist>
-        Distribution profile name as used in cloud_builder.kiwi
+        Distribution profile name as set int the .kiwi
+        package buildroot metadata file
 
     --request-id=<UUID>
         UUID for this prepare process
@@ -53,9 +54,9 @@ def main() -> None:
     cb-prepare - creates a chroot tree suitable to build a
     package inside of it, also known as buildroot. The KIWI
     appliance builder is used to create the buildroot
-    according to a metadata definition file named:
+    according to a metadata definition file from:
 
-        cloud_builder.kiwi
+        Defaults.get_cloud_builder_kiwi_file_name()
 
     which needs to be present as part of the package sources.
 

--- a/cloud_builder/defaults.py
+++ b/cloud_builder/defaults.py
@@ -31,6 +31,8 @@ status_flags = NamedTuple(
         ('incompatible_build_arch', str),
         ('reset_running_build', str),
         ('package_not_existing', str),
+        ('package_metadata_not_existing', str),
+        ('package_target_not_configured', str),
         ('invalid_metadata', str)
     ]
 )
@@ -40,6 +42,22 @@ class Defaults:
     """
     Implements Cloud Builder project default values
     """
+    @staticmethod
+    def get_cloud_builder_metadata_file_name() -> str:
+        """
+        Return name of package configuration file to be used
+        with Cloud Builder
+        """
+        return 'cloud_builder.yml'
+
+    @staticmethod
+    def get_cloud_builder_kiwi_file_name() -> str:
+        """
+        Return name of package buildroot kiwi config file to
+        be used with Cloud Builder
+        """
+        return 'cloud_builder.kiwi'
+
     @staticmethod
     def get_package_request_queue_name() -> str:
         """
@@ -146,7 +164,9 @@ class Defaults:
             incompatible_build_arch='incompatible build arch',
             reset_running_build='reset running build',
             package_not_existing='package does not exist',
-            invalid_metadata='invalid package metadata'
+            package_metadata_not_existing='package metadata does not exist',
+            invalid_metadata='invalid package metadata',
+            package_target_not_configured='package target not configured'
         )
 
     @staticmethod

--- a/cloud_builder/package_metadata/package_metadata.py
+++ b/cloud_builder/package_metadata/package_metadata.py
@@ -44,7 +44,8 @@ class CBPackageMetaData:
         :param CBCloudLogger log: CBCloudLogger object instance
         :param str request_id: UUID
         :param str filename:
-            alternative meta data file name, default is cloud_builder.yml
+            alternative meta data file name, default is
+            Defaults.get_cloud_builder_metadata_file_name()
 
         :return: yaml dictionary data or empty dict
 
@@ -52,7 +53,7 @@ class CBPackageMetaData:
         """
         config_data: Dict[str, str] = {}
         config_file = filename or os.path.join(
-            package_path, 'cloud_builder.yml'
+            package_path, Defaults.get_cloud_builder_metadata_file_name()
         )
         if os.path.isfile(config_file):
             with open(config_file, 'r') as config:

--- a/cloud_builder/package_request/package_request.py
+++ b/cloud_builder/package_request/package_request.py
@@ -16,7 +16,6 @@
 # along with Cloud Builder.  If not, see <http://www.gnu.org/licenses/>
 #
 from typing import Dict
-from cloud_builder.defaults import Defaults
 from cloud_builder.identity import CBIdentity
 
 
@@ -28,15 +27,16 @@ class CBPackageRequest:
         self.package_request_dict: Dict = {}
         self.package_request_schema_version = 0.1
 
-    def set_package_source_change_request(
-        self, package: str, arch: str
+    def set_package_build_request(
+        self, package: str, arch: str, dist: str, action: str
     ) -> None:
         self.package_request_dict = {
             'schema_version': self.package_request_schema_version,
             'request_id': CBIdentity.get_request_id(),
             'package': package,
             'arch': arch,
-            'action': Defaults.get_status_flags().package_changed
+            'dist': dist,
+            'action': action
         }
 
     def get_data(self) -> Dict:

--- a/cloud_builder/package_request/package_request_schema.py
+++ b/cloud_builder/package_request/package_request_schema.py
@@ -36,6 +36,11 @@ package_request_schema = {
         'type': 'string',
         'nullable': False
     },
+    'dist': {
+        'required': True,
+        'type': 'string',
+        'nullable': False
+    },
     'action': {
         'required': True,
         'type': 'string',

--- a/cloud_builder/response/response.py
+++ b/cloud_builder/response/response.py
@@ -64,61 +64,85 @@ class CBResponse:
         }
 
     def set_package_update_request_response(
-        self, message: str, response_code: str, package: str, arch: str
+        self, message: str, response_code: str, package: str,
+        arch: str, dist: str
     ) -> None:
         self.response_dict = {
             **self.response_dict,
             'message': message,
             'response_code': response_code,
             'package': package,
-            'arch': arch
+            'arch': arch,
+            'dist': dist
         }
 
     def set_package_build_scheduled_response(
-        self, message: str, response_code: str, package: str, arch: str
+        self, message: str, response_code: str, package: str,
+        arch: str, dist: str
     ) -> None:
         self.response_dict = {
             **self.response_dict,
             'message': message,
             'response_code': response_code,
             'package': package,
-            'arch': arch
+            'arch': arch,
+            'dist': dist
         }
 
     def set_buildhost_arch_incompatible_response(
-        self, message: str, response_code: str, package: str, arch: str
+        self, message: str, response_code: str, package: str
     ) -> None:
         self.response_dict = {
             **self.response_dict,
             'message': message,
             'response_code': response_code,
-            'package': package,
-            'arch': arch
+            'package': package
         }
 
     def set_package_jobs_reset_response(
-        self, message: str, response_code: str, package: str, arch: str
+        self, message: str, response_code: str, package: str,
+        arch: str, dist: str
     ) -> None:
         self.response_dict = {
             **self.response_dict,
             'message': message,
             'response_code': response_code,
             'package': package,
-            'arch': arch
+            'arch': arch,
+            'dist': dist
         }
 
     def set_package_not_existing_response(
-        self, message: str, response_code: str, package: str, arch: str
+        self, message: str, response_code: str, package: str
     ) -> None:
         self.response_dict = {
             **self.response_dict,
             'message': message,
             'response_code': response_code,
-            'package': package,
-            'arch': arch
+            'package': package
         }
 
     def set_package_invalid_metadata_response(
+        self, message: str, response_code: str, package: str
+    ) -> None:
+        self.response_dict = {
+            **self.response_dict,
+            'message': message,
+            'response_code': response_code,
+            'package': package
+        }
+
+    def set_package_invalid_target_response(
+        self, message: str, response_code: str, package: str
+    ) -> None:
+        self.response_dict = {
+            **self.response_dict,
+            'message': message,
+            'response_code': response_code,
+            'package': package
+        }
+
+    def set_package_metadata_not_existing_response(
         self, message: str, response_code: str, package: str
     ) -> None:
         self.response_dict = {

--- a/cloud_builder/response/response_schema.py
+++ b/cloud_builder/response/response_schema.py
@@ -51,6 +51,11 @@ response_schema = {
         'type': 'string',
         'nullable': False
     },
+    'dist': {
+        'required': False,
+        'type': 'string',
+        'nullable': False
+    },
     'log_file': {
         'required': False,
         'type': 'string',

--- a/test/unit/broker/base_test.py
+++ b/test/unit/broker/base_test.py
@@ -80,11 +80,13 @@ class TestCBMessageBrokerBase:
     def test_validate_message_with_schema_ok(self, mock_acknowledge):
         assert self.broker.validate_message_with_schema(
             "{'schema_version': 0.1, 'request_id': 'uuid', "
-            "'package': 'vim', 'arch': 'x86_64', 'action': 'action'}",
+            "'package': 'vim', 'arch': 'x86_64', 'dist': 'TW', "
+            "'action': 'action'}",
             package_request_schema
         ) == {
             'action': 'action',
             'arch': 'x86_64',
+            'dist': 'TW',
             'package': 'vim',
             'request_id': 'uuid',
             'schema_version': 0.1

--- a/test/unit/package_request/package_request_test.py
+++ b/test/unit/package_request/package_request_test.py
@@ -8,12 +8,13 @@ class TestCBPackageRequest:
         self.request = CBPackageRequest()
 
     @patch('cloud_builder.package_request.package_request.CBIdentity')
-    def test_set_package_source_change_request(self, mock_CBIdentity):
-        self.request.set_package_source_change_request('vim', 'x86_64')
+    def test_set_package_build_request(self, mock_CBIdentity):
+        self.request.set_package_build_request('vim', 'x86_64', 'TW', 'action')
         assert self.request.get_data() == {
-            'action': 'package source changed',
+            'action': 'action',
             'arch': 'x86_64',
             'package': 'vim',
+            'dist': 'TW',
             'request_id': mock_CBIdentity.get_request_id.return_value,
             'schema_version': 0.1
         }

--- a/test/unit/response/response_test.py
+++ b/test/unit/response/response_test.py
@@ -39,62 +39,63 @@ class TestCBResponse:
 
     def test_set_package_update_request_response(self):
         self.response.set_package_update_request_response(
-            'message', 'response_code', 'package', 'arch'
+            'message', 'response_code', 'package', 'arch', 'dist'
         )
         assert self.response.get_data() == {
             **self.response.response_dict,
             'message': 'message',
             'response_code': 'response_code',
             'package': 'package',
-            'arch': 'arch'
+            'arch': 'arch',
+            'dist': 'dist'
         }
 
     def test_set_package_build_scheduled_response(self):
         self.response.set_package_build_scheduled_response(
-            'message', 'response_code', 'package', 'arch'
+            'message', 'response_code', 'package', 'arch', 'dist'
         )
         assert self.response.get_data() == {
             **self.response.response_dict,
             'message': 'message',
             'response_code': 'response_code',
             'package': 'package',
-            'arch': 'arch'
+            'arch': 'arch',
+            'dist': 'dist'
         }
 
     def test_set_buildhost_arch_incompatible_response(self):
         self.response.set_buildhost_arch_incompatible_response(
-            'message', 'response_code', 'package', 'arch'
+            'message', 'response_code', 'package'
         )
         assert self.response.get_data() == {
             **self.response.response_dict,
             'message': 'message',
             'response_code': 'response_code',
-            'package': 'package',
-            'arch': 'arch'
+            'package': 'package'
         }
 
     def test_set_package_jobs_reset_response(self):
         self.response.set_package_jobs_reset_response(
-            'message', 'response_code', 'package', 'arch'
+            'message', 'response_code', 'package', 'arch', 'dist'
         )
         assert self.response.get_data() == {
             **self.response.response_dict,
             'message': 'message',
             'response_code': 'response_code',
             'package': 'package',
-            'arch': 'arch'
+            'arch': 'arch',
+            'dist': 'dist'
         }
 
     def test_set_package_not_existing_response(self):
         self.response.set_package_not_existing_response(
-            'message', 'response_code', 'package', 'arch'
+            'message', 'response_code', 'package'
         )
         assert self.response.get_data() == {
             **self.response.response_dict,
             'message': 'message',
             'response_code': 'response_code',
-            'package': 'package',
-            'arch': 'arch'
+            'package': 'package'
         }
 
     def test_set_package_invalid_metadata_response(self):


### PR DESCRIPTION
A package build request contains arch + dist. If we want
to build for multiple arch+dist targets it should be one
request for each of them. Thus the cb_scheduler needs to
be refactored to care for this information in the request