### PR TITLE
Rebuild buildroot om demand

### DIFF
--- a/cloud_builder/cb_fetch.py
+++ b/cloud_builder/cb_fetch.py
@@ -138,11 +138,17 @@ def update_project() -> None:
         )
         if package_config:
             status_flags = Defaults.get_status_flags()
+            request_action = status_flags.package_changed
+            buildroot_config = Defaults.get_cloud_builder_kiwi_file_name()
+            if buildroot_config in changed_packages[package_source_path]:
+                # buildroot setup is part of changes list. This
+                # triggers a new build of the package buildroot
+                request_action = status_flags.package_and_meta_changed
             for target in package_config.get('distributions') or []:
                 package_request = CBPackageRequest()
                 package_request.set_package_build_request(
                     package_source_path, target['arch'], target['dist'],
-                    status_flags.package_changed
+                    request_action
                 )
                 broker.send_package_request(package_request)
                 request = package_request.get_data()

--- a/cloud_builder/defaults.py
+++ b/cloud_builder/defaults.py
@@ -21,6 +21,7 @@ from typing import NamedTuple
 status_flags = NamedTuple(
     'status_flags', [
         ('package_changed', str),
+        ('package_and_meta_changed', str),
         ('package_build_failed', str),
         ('package_build_succeeded', str),
         ('package_build_running', str),
@@ -154,12 +155,13 @@ class Defaults:
         """
         return status_flags(
             package_changed='package source changed',
+            package_and_meta_changed='package and its metadata changed',
             package_build_failed='package build failed',
             package_build_succeeded='package build succeeded',
             package_build_running='package build running',
             buildroot_setup_failed='build root setup failed',
             buildroot_setup_succeeded='build root setup succeeded',
-            package_update_request='package update request scheduled',
+            package_update_request='fetch service update request scheduled',
             package_request_accepted='package request accepted',
             incompatible_build_arch='incompatible build arch',
             reset_running_build='reset running build',


### PR DESCRIPTION
If the kiwi file for creating the package buildroot has
changed the fetch service will send a different action
status which causes the buildroot on the runner to be
deleted